### PR TITLE
feat: Implementar servidor fastmcp para archivos Markdown

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,0 +1,52 @@
+import asyncio
+import json
+from fastmcp import Client
+
+async def main():
+    # Para conectarse a un subproceso, se debe usar el formato de configuración
+    # estándar de MCP, que incluye un diccionario `mcpServers`.
+    server_config = {
+        "mcpServers": {
+            "default": {
+                "command": "python",
+                "args": ["main.py"]
+            }
+        }
+    }
+
+    async with Client(server_config) as client:
+        print("Cliente conectado al servidor.")
+
+        # 1. Listar los recursos disponibles para confirmar la conexión
+        resources = await client.list_resources()
+        print(f"\\nRecursos disponibles: {resources}")
+
+        # 2. Invocar el recurso para listar archivos
+        print("\\n--- Listando archivos disponibles ---")
+        # El resultado es una lista con un objeto TextResourceContents, cuyo texto es un JSON.
+        list_result = await client.read_resource("markdown://files")
+        json_text = list_result[0].text
+        available_files = json.loads(json_text)
+        print(f"Archivos: {available_files}")
+
+        # 3. Si hay archivos, leer el primero de la lista
+        if available_files:
+            filename_to_read = available_files[0]
+            print(f"\\n--- Leyendo el contenido de: {filename_to_read} ---")
+
+            # Invocamos el recurso dinámico con el nombre del archivo
+            content_result = await client.read_resource(f"markdown://file/{filename_to_read}")
+            print(content_result[0].text)
+
+        # 4. Intentar leer un archivo que no existe
+        print("\\n--- Intentando leer un archivo que no existe ---")
+        not_found_result = await client.read_resource("markdown://file/archivo_inexistente.md")
+        print(not_found_result[0].text)
+
+        # 5. Intentar leer el archivo excluido
+        print("\\n--- Intentando leer el archivo excluido (README.md) ---")
+        excluded_result = await client.read_resource("markdown://file/README.md")
+        print(excluded_result[0].text)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/main.py
+++ b/main.py
@@ -1,0 +1,49 @@
+import os
+import glob
+from fastmcp import FastMCP
+
+# 1. Instanciar el servidor
+mcp = FastMCP("Servidor de Archivos Markdown")
+
+# --- Carga de archivos desde el disco ---
+def load_markdown_files():
+    """
+    Busca y carga todos los archivos .md en el directorio actual en un diccionario.
+    """
+    files_dict = {}
+    for filepath in glob.glob("*.md"):
+        filename = os.path.basename(filepath)
+        try:
+            with open(filepath, 'r', encoding='utf-8') as f:
+                files_dict[filename] = f.read()
+        except Exception as e:
+            print(f"Error al leer el archivo {filename}: {e}")
+            files_dict[filename] = f"Error al leer el archivo: {e}"
+    return files_dict
+
+# Cargar los archivos al iniciar el script
+loaded_files = load_markdown_files()
+# -----------------------------------------
+
+# Lista de archivos a excluir
+EXCLUDED_FILES = ["README.md"]
+
+# Recurso para listar los archivos disponibles
+@mcp.resource("markdown://files")
+def list_files():
+    """Devuelve una lista de los archivos .md disponibles."""
+    available_files = [f for f in loaded_files.keys() if f not in EXCLUDED_FILES]
+    return available_files
+
+# Recurso dinámico para obtener el contenido de un archivo
+@mcp.resource("markdown://file/{filename}")
+def get_file(filename: str):
+    """Devuelve el contenido de un archivo .md específico."""
+    if filename in EXCLUDED_FILES:
+        return f"Acceso denegado al archivo: {filename}"
+    return loaded_files.get(filename, f"Error: Archivo no encontrado: {filename}")
+
+if __name__ == "__main__":
+    # Ejecutar el servidor. Por defecto usa stdio, que es lo que el cliente esperará.
+    print("Servidor MCP iniciado. Esperando comandos a través de stdio...")
+    mcp.run()

--- a/post1.md
+++ b/post1.md
@@ -1,0 +1,3 @@
+# Este es el Post 1 (desde un archivo)
+
+Este es el contenido del primer post, leído desde un archivo físico.

--- a/post2.md
+++ b/post2.md
@@ -1,0 +1,5 @@
+# Título del Post 2 (desde un archivo)
+
+- Item de lista 1
+- Item de lista 2
+- Item de lista 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+fastmcp


### PR DESCRIPTION
Añade una aplicación Python que utiliza `fastmcp` para servir el contenido de los archivos Markdown (`.md`) de un directorio.

Características principales:
- Un servidor en `main.py` que se inicia y carga dinámicamente todos los archivos `.md` del directorio actual.
- Expone dos recursos MCP:
  - `markdown://files`: Devuelve una lista de todos los archivos `.md` disponibles.
  - `markdown://file/{filename}`: Devuelve el contenido del archivo especificado.
- Excluye de la lista los archivos especificados en la lista `EXCLUDED_FILES` (actualmente, solo `README.md`).
- Un cliente de ejemplo en `client.py` que demuestra cómo conectarse al servidor, listar los archivos y leer su contenido.
- Incluye un archivo `requirements.txt` para la instalación de dependencias.