### PR TITLE
feat: Añadir documentación sobre despliegue, observabilidad y pruebas…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,27 +32,33 @@ información de forma modular.
 
 - [architecture.md](architecture.md) – Describe la estructura y componentes del sistema, cómo
   interactúan y las decisiones técnicas que guían su evolución.
-- [arquitecture-data-analytics.md](arquitecture-data-analytics.md) – Describe la estructura y componentes del sistema, cómo
-  interactúan y las decisiones técnicas que guían su evolución para los proyectos en gcp de analitica y data
+- [arquitecture-data-analytics.md](arquitecture-data-analytics.md) – Describe la estructura y componentes del sistema, cómo interactúan y las decisiones técnicas que guían su evolución para los proyectos en gcp de analitica y data.
 - [database.md](database.md) – Documenta las estructuras de datos persistentes, sus campos, tipos,
   relaciones y convenciones de modelado utilizadas.
 - [database-er.md](database-er.md) – Incluye diagramas que representan visualmente tablas, campos y
   relaciones o estructuras no relacionales.
 - [testing.md](testing.md) – Define la estrategia de pruebas, tipos de test, herramientas y
   convenciones para garantizar la calidad del software.
+- [testing-data-analytics.md](testing-data-analytics.md) – Define la estrategia de pruebas, tipos de test, herramientas y convenciones para garantizar la calidad del software para proyectos en gcp de analitica y data.
 - [security.md](security.md) – Enumera políticas, prácticas y estándares de seguridad que protegen
   datos, accesos y la integridad del sistema.
+- [security-data-analytics.md](security-data-analytics.md) – Enumera políticas, prácticas y estándares de seguridad que protegen datos, accesos y la integridad del sistema para proyectos en gcp de analitica y data.
 - [python-code-guidelines.md](python-code-guidelines.md) – Define el estándar para escribir y
   mantener código Python, incluyendo reglas de estilo, configuración de linters, formateadores,
   validadores, manejo de errores y pruebas, con el submódulo `.code_quality` como dependencia
   obligatoria.
+- [python-code-guidelines-data-analytics.md](python-code-guidelines-data-analytics.md) – Define el estándar para escribir y mantener código Python, incluyendo reglas de estilo, configuración de linters, formateadores,
+  validadores, manejo de errores y pruebas, con el submódulo `.code_quality` como dependencia
+  obligatoria para proyectos en gcp de analitica y data.
 - [frontend-code-guidelines.md](frontend-code-guidelines.md) – Define el estándar para escribir y
   mantener código de frontend, incluyendo convenciones de estilo, estructura de componentes,
   validaciones, seguridad y pruebas específicas para proyectos de interfaz.
 - [deployment.md](deployment.md) – Detalla los pasos, entornos, herramientas y validaciones
   necesarias para un despliegue seguro y controlado.
+- [deployment-data-analytics.md](deployment-data-analytics.md) – Detalla los pasos, entornos, herramientas y validaciones necesarias para un despliegue seguro y controlado para proyectos en gcp de analitica y data.
 - [observability.md](observability.md) – Define cómo se monitorea el sistema, qué métricas se siguen
   y cómo se gestionan alertas y eventos críticos.
+- [deployment-data-analytics.md](deployment-data-analytics.md) – Define cómo se monitorea el sistema, qué métricas se siguen y cómo se gestionan alertas y eventos críticos para proyectos en gcp de analitica y data.
 
 ### Guías generales
 
@@ -67,3 +73,11 @@ información de forma modular.
   trazabilidad con las tareas asociadas.
 - [tasks-guidelines.md](tasks-guidelines.md) – Explica cómo redactar y estructurar tareas en formato
   compatible con el copiloto para ejecución asistida.
+- [main.py](main.py)- Un servidor en `main.py` que se inicia y carga dinámicamente todos los archivos `.md` del directorio actual.
+  - Expone dos recursos MCP:
+    - `markdown://files`: Devuelve una lista de todos los archivos `.md` disponibles.
+    - `markdown://file/{filename}`: Devuelve el contenido del archivo especificado.
+  - Excluye de la lista los archivos especificados en la lista `EXCLUDED_FILES` (actualmente, solo `README.md`).
+  - Ejecutable con python `.\main.py`
+- [client.py](client.py)- Un cliente de ejemplo en `client.py` que demuestra cómo conectarse al servidor, listar los archivos y leer su contenido.
+- [requirements.txt](requirements.txt)- Incluye un archivo `requirements.txt` para la instalación de dependencias.

--- a/deployment-data-analytics.md
+++ b/deployment-data-analytics.md
@@ -1,0 +1,63 @@
+# Deployment
+
+Este documento detalla los pasos, entornos, herramientas y validaciones necesarias para realizar un despliegue seguro y controlado de la aplicación y su infraestructura.
+
+## Estrategia de Ramas y Entornos
+
+Nuestro flujo de trabajo se basa en una estrategia de ramas que se mapea directamente a nuestros entornos en Google Cloud Platform. Esto garantiza un ciclo de vida de desarrollo y despliegue predecible.
+
+### Entorno de QA (Calidad)
+
+Rama: develop
+
+Proyecto GCP: xx-main-qa
+
+Propósito: Este entorno se utiliza para la validación de nuevas funcionalidades y para la ejecución de pruebas de integración sobre los servicios recién desplegados.
+
+### Entorno de Producción
+
+Rama: master
+
+Proyecto GCP: xx-main-prod
+
+Propósito: Es el entorno final que sirve a los usuarios. Solo el código que ha sido validado y aprobado puede llegar aquí.
+
+## Pipeline de Despliegue (CI/CD)
+
+Todo el proceso de despliegue está orquestado por GitLab CI/CD. El pipeline consta de una serie de etapas secuenciales y bloqueantes, lo que significa que el fallo en una etapa detiene todo el proceso para prevenir errores.
+
+### Etapa 1: Pruebas y Análisis de Calidad (Bloqueante)
+
+Disparador: Se ejecuta en cada commit a las ramas develop y master.
+
+Acciones:
+
+Linters y Formateadores: Se ejecutan herramientas como flake8 y pylint para asegurar la consistencia y calidad del código.
+
+Análisis de Seguridad: Sonar escanea el código en busca de vulnerabilidades de seguridad y "code smells".
+
+Pruebas Unitarias y Cobertura: Se ejecutan las pruebas unitarias y se valida que el código nuevo cumpla con el umbral del 80% de cobertura.
+
+Resultado: Si alguna de estas validaciones falla, el pipeline se detiene y no se procede al despliegue.
+
+### Etapa 2: Análisis de Seguridad con SonarQube (Bloqueante)
+
+Disparador: Se ejecuta si la Etapa 1 es exitosa.
+
+Acción: SonarQube escanea el código en busca de vulnerabilidades de seguridad, "code smells" y bugs.
+
+Resultado: El pipeline se detiene si se detectan problemas que no cumplen con el umbral de calidad (Quality Gate) definido en SonarQube.
+
+### Etapa 3: Despliegue con Pulumi (Bloqueante)
+
+Disparador: Se ejecuta automáticamente si la Etapa 1 es exitosa.
+
+Acción: Se invoca a Pulumi para que sincronice el estado de la infraestructura definido en el código (carpeta iac/) con el entorno de GCP correspondiente. Pulumi se encarga de crear, actualizar o eliminar los recursos necesarios (Cloud Run, Schedulers, etc.) y desplegar la nueva versión de la aplicación.
+
+### Etapa 4: Pruebas de Integración (Post-Despliegue)
+
+Disparador: Se ejecuta después de un despliegue exitoso en el entorno de QA (develop).
+
+Acción: Se lanza un conjunto de pruebas de integración que validan el comportamiento del servicio desplegado en un entorno real.
+
+Nota: Actualmente, este paso solo aplica para los componentes de tipo "servicio" y se considera una validación adicional.

--- a/observability-data-analytics.md
+++ b/observability-data-analytics.md
@@ -1,0 +1,41 @@
+# Filosofía de Observabilidad
+
+Nuestra estrategia se centra en la acción y la relevancia. No buscamos medirlo todo, sino monitorear las señales vitales que nos permitan detectar problemas, diagnosticar sus causas y responder a ellos de manera efectiva. Utilizamos las herramientas nativas de Google Cloud Platform para centralizar nuestra observabilidad.
+
+## Monitoreo y Métricas Clave
+
+Herramienta: Google Cloud Logging.
+
+### Errores
+
+Descripción: Monitoreamos activamente los logs en busca de entradas con severidad ERROR. Este es nuestro principal indicador de que algo está funcionando mal en la aplicación. La política de alerta específica para esto se define en la sección de Alertas.
+
+### Latencia
+
+Descripción: Se monitorea el tiempo de respuesta de las peticiones a nuestros servicios. Una latencia elevada es un indicador clave de degradación del rendimiento o de problemas inminentes.
+
+## Gestión de Alertas
+
+### Alerta de Tasa de Errores
+
+Condición: Se dispara una alerta si se registran 10 o más eventos de log con severidad "ERROR" en el transcurso del mismo día.
+
+Fuente: Definida en el código de infraestructura iac/pulumi_resources/alert_policy.py.
+
+### Alerta de Alta Latencia
+
+Condición: Se dispara una alerta para cualquier petición que tarde más de 30 segundos en completarse.
+
+## Dashboards y Visualización
+
+Herramienta Principal: Google Cloud Monitoring Dashboards.
+
+Para la visualización del estado del sistema, utilizamos los paneles predeterminados que Google Cloud proporciona para servicios como Cloud Run. Estos dashboards son el punto de partida para cualquier investigación visual del rendimiento del servicio
+
+## Métricas de Negocio
+
+La implementación de métricas específicas de negocio sigue un proceso de planificación estricto para asegurar que cada métrica tenga un propósito claro y un resultado esperado.
+
+Proceso de Definición: Antes de implementar cualquier métrica de negocio (ej: "procesos completados por hora"), es requisito indispensable tener una sesión de planificación con el Director de Analítica. En esta sesión, se define el plan, el resultado esperado y cómo se visualizará.
+
+Política: No se despliegan métricas de negocio a producción si no han pasado por este proceso de validación y planificación estratégica

--- a/post1.md
+++ b/post1.md
@@ -1,3 +1,0 @@
-# Este es el Post 1 (desde un archivo)
-
-Este es el contenido del primer post, leído desde un archivo físico.

--- a/post2.md
+++ b/post2.md
@@ -1,5 +1,0 @@
-# Título del Post 2 (desde un archivo)
-
-- Item de lista 1
-- Item de lista 2
-- Item de lista 3

--- a/python-code-guidelines-data-analytics.md
+++ b/python-code-guidelines-data-analytics.md
@@ -1,0 +1,42 @@
+
+# Filosofía General
+
+El código se lee más de lo que se escribe: Priorizamos la claridad y la legibilidad sobre la concisión excesiva.
+
+La calidad es responsabilidad de todos: Las herramientas automatizadas son una ayuda, no un sustituto del buen juicio del desarrollador.
+
+Consistencia ante todo: Un estilo de código uniforme en todo el proyecto facilita la comprensión y reduce la carga cognitiva.
+
+## Estilo y Formateo de Código
+
+Nuestro estándar se basa en PEP 8, con algunas reglas específicas y reforzadas.
+
+Límite de Longitud de Línea: Todas las líneas de código deben tener un máximo de 80 caracteres. Esto mejora la legibilidad, especialmente en pantallas divididas.
+
+Convención de Nomenclatura: Se debe usar snake_case para todas las variables y nombres de funciones (ej: calcular_total_factura).
+
+## Calidad y Robustez del Código
+
+Más allá del estilo, el código debe ser robusto, mantenible y predecible.
+
+Complejidad Ciclomática: Las funciones y métodos no deben exceder una complejidad ciclomática de 15. Si una función es más compleja, es una señal de que debe ser refactorizada en unidades más pequeñas y manejables. pylint y flake8 (con plugins) medirán esto.
+
+Manejo de Excepciones: Está prohibido usar excepciones genéricas como except Exception: o except:. Siempre se deben capturar las excepciones más específicas posibles (ej: except ValueError:, except FileNotFoundError:). Esto evita ocultar errores inesperados y hace que el flujo de control sea más explícito.
+
+## Herramientas de Calidad de Código
+
+Nuestro flujo de trabajo automatizado se apoya en las siguientes herramientas:
+
+flake8: Un linter rápido y eficiente que verifica el cumplimiento de PEP 8, errores de sintaxis y la complejidad del código.
+
+pylint: Proporciona un análisis más profundo del código, detectando "code smells", reforzando estándares de codificación y buscando errores lógicos.
+
+bandit: Una herramienta de análisis estático de seguridad (SAST) que escanea el código en busca de vulnerabilidades de seguridad comunes en Python.
+
+sqlfluff: Un linter de SQL que garantiza la consistencia y legibilidad de las consultas.
+
+Uso en Python: Dado que nuestro código SQL a menudo se encuentra dentro de variables de cadena (strings) en Python, sqlfluff se configurará para analizar estas cadenas, asegurando que incluso el SQL embebido cumpla con nuestros estándares de calidad
+
+## Principios de Diseño de Software: SOLID
+
+Además de las reglas de estilo y calidad, nuestro equipo se adhiere a los principios de diseño SOLID para crear un software robusto y fácil de mantener.

--- a/security-data-analytics.md
+++ b/security-data-analytics.md
@@ -1,0 +1,36 @@
+# Gestión de Secretos y Credenciales
+
+La protección de credenciales es la primera línea de defensa para nuestros sistemas.
+
+Prohibición de Credenciales Quemadas: Está estrictamente prohibido incrustar o "quemar" cualquier tipo de credencial (claves de API, contraseñas, tokens) directamente en el código fuente.
+
+Gestor de Secretos Centralizado: Todas las credenciales deben ser gestionadas a través de un servicio seguro como Google Secret Manager. La aplicación recuperará estos secretos en tiempo de ejecución, nunca durante el proceso de construcción (build).
+
+Generación Segura: Las claves, como la API_KEY del servicio, se generan de forma segura y aleatoria durante el despliegue a través de Pulumi, como se observa en el fichero iac/__main__.py, asegurando que sean únicas para cada entorno.
+
+## Seguridad de Infraestructura y Entornos
+
+La segregación de entornos es fundamental para prevenir que los problemas de un ambiente afecten a otro.
+
+Separación por Proyecto de GCP: Cada entorno (ej. desarrollo, QA, producción) debe estar desplegado en su propio proyecto de Google Cloud Platform. Esto garantiza un aislamiento completo de recursos, redes y permisos.
+
+Nomenclatura Estándar: Los proyectos seguirán una nomenclatura clara que identifique su propósito y entorno, como por ejemplo: xx-main-qa y xx-main-prod.
+
+Identidad y Gestión de Accesos (IAM) identidade
+El acceso a los recursos de la nube debe ser controlado y limitado rigurosamente.
+
+Principio de Mínimo Privilegio: Todas las cuentas, tanto de usuario como de servicio, deben operar bajo este principio. Se les otorgarán únicamente los permisos estrictamente necesarios para realizar sus funciones designadas.
+
+Uso de Roles Predefinidos: Para la gestión de permisos en GCP, se priorizará el uso de los roles predefinidos de Google Cloud. Esto asegura que los permisos son gestionados y mantenidos por Google, reduciendo el riesgo de configuraciones erróneas. Se crearán roles personalizados solo cuando sea absolutamente necesario y con la debida justificación.
+
+Cuentas de Servicio Dedicadas: Cada servicio (como el Cloud Run principal o los jobs programados) debe tener su propia cuenta de servicio dedicada (ej: {resource_name}-sa). Esto permite asignarles permisos granulares sin afectar a otros componentes.
+
+## Seguridad del Código y Dependencias
+
+La seguridad debe estar integrada en el ciclo de vida del desarrollo de software (DevSecOps).
+
+Análisis Estático de Seguridad (SAST): Se realizarán escaneos de vulnerabilidades en el código fuente de manera regular utilizando herramientas como Sonar. Los resultados de estos análisis deben ser revisados y las vulnerabilidades críticas deben ser resueltas antes de desplegar en producción.
+
+Gestión de Dependencias (SCA): Las dependencias de terceros, listadas en archivos como requirements.txt, deben ser monitoreadas continuamente en busca de vulnerabilidades conocidas.
+
+Seguridad de Contenedores: Las imágenes base de Docker (ej: python:3.11.8-slim) deben ser escaneadas en busca de vulnerabilidades y actualizadas a versiones seguras de forma periódica.

--- a/testing-data-analytics.md
+++ b/testing-data-analytics.md
@@ -1,0 +1,45 @@
+# Filosofía y Responsabilidades
+
+La calidad del software es una responsabilidad compartida, pero la implementación de las pruebas recae directamente en los desarrolladores. Nuestro enfoque se basa en el principio de que quien construye una funcionalidad es la persona más indicada para construir también su red de seguridad a través de pruebas automatizadas.
+
+Responsable Principal: Cada desarrollador es responsable de escribir las pruebas para el código que produce. Esto incluye pruebas unitarias y, cuando sea aplicable, pruebas de integración.
+
+Momento de Escritura: Las pruebas deben ser escritas durante la fase de desarrollo de una nueva funcionalidad o de la corrección de un error. Lo ideal es que el código y sus pruebas se entreguen juntos en el mismo Merge Request (MR) para asegurar que todo nuevo aporte al repositorio esté debidamente validado.
+
+## Estándares de Calidad y Cobertura
+
+Para garantizar un nivel de calidad consistente y evitar la degradación del código, se establece un estándar de cobertura mínimo.
+
+Métrica de Cobertura: La cobertura de pruebas se mide por el número de líneas de código ejecutables que son alcanzadas por las pruebas automatizadas.
+
+Requisito de Cobertura:
+
+Para código nuevo: Se exige una cobertura mínima del 80% en todas las nuevas funcionalidades o archivos añadidos al proyecto.
+
+Comportamiento en Merge Requests: Si un MR disminuye la cobertura general del proyecto, el pipeline mostrará una advertencia. Aunque no bloqueará la fusión, se espera que el equipo revise el caso y justifique la disminución. No se debe permitir que la deuda técnica en pruebas se acumule.
+
+## Herramientas y Automatización
+
+Se ha definido un conjunto de herramientas estándar para mantener la consistencia en el desarrollo y ejecución de las pruebas.
+
+Frameworks de Pruebas: Se utilizarán los frameworks Pytest y Unittest para la escritura de las pruebas. Pytest es preferido por su sintaxis concisa y su potente sistema de fixtures.
+
+Mocks y Dobles de Prueba: Para aislar componentes y simular dependencias externas (como APIs o bases de datos), la librería recomendada es unittest.mock, que forma parte de la biblioteca estándar de Python.
+
+Ejecución y CI/CD: La ejecución automatizada de todo el conjunto de pruebas se realiza en el pipeline de GitLab CI/CD con cada commit y merge request. Esto garantiza una retroalimentación rápida sobre la calidad del código.
+
+## Convenciones y Buenas Prácticas
+
+Para asegurar que las pruebas sean legibles, mantenibles y consistentes en todo el proyecto, se deben seguir las siguientes convenciones:
+
+Nomenclatura de Archivos: Todos los archivos que contengan pruebas deben tener el prefijo test_. Por ejemplo: test_user_model.py.
+
+Nomenclatura de Funciones: Todas las funciones de prueba dentro de esos archivos también deben comenzar con el prefijo test_. Por ejemplo: def test_create_user_successfully():.
+
+Estructura de la Prueba: Se recomienda seguir el patrón Arrange-Act-Assert (AAA) para dar una estructura clara a cada prueba:
+
+Arrange (Organizar): Configura las condiciones iniciales y las entradas de la prueba.
+
+Act (Actuar): Ejecuta la función o el código que se está probando.
+
+Assert (Afirmar): Verifica que el resultado o el estado final sea el esperado.


### PR DESCRIPTION
feat: Implementar servidor fastmcp para archivos Markdown + archivos para proyectos en GCP de analítica y data

Añade una aplicación Python que utiliza `fastmcp` para servir el contenido de los archivos Markdown (`.md`) de un directorio.

Características principales:
- Un servidor en `main.py` que se inicia y carga dinámicamente todos los archivos `.md` del directorio actual.
- Expone dos recursos MCP:
  - `markdown://files`: Devuelve una lista de todos los archivos `.md` disponibles.
  - `markdown://file/{filename}`: Devuelve el contenido del archivo especificado.
- Excluye de la lista los archivos especificados en la lista `EXCLUDED_FILES` (actualmente, solo `README.md`).
- Un cliente de ejemplo en `client.py` que demuestra cómo conectarse al servidor, listar los archivos y leer su contenido.
- Incluye un archivo `requirements.txt` para la instalación de dependencias.